### PR TITLE
Added $self implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,8 @@ node_modules/
 package-lock.json
 bun.lockb
 
+# user plugins
+src/userplugins/
+
 # mac config
 **/.DS_Store

--- a/dist/bb.min.js
+++ b/dist/bb.min.js
@@ -2154,7 +2154,8 @@ const createPlugin = ({
   onLoad,
   onStart,
   required,
-  disabled
+  disabled,
+  ...custom
 }) => {
   if (!name || !authors?.length || !onLoad && !onStart && !patches && !styles)
     return console.error(`ERROR: Plugin does not have a title, authors, or executable functions.`);
@@ -2170,11 +2171,12 @@ const createPlugin = ({
     onStart: onStart || (() => {
     }),
     required: required || false,
-    disabled: disabled || false
+    disabled: disabled || false,
+    ...custom
   };
   return plugin;
 };
-const index$h = () => createPlugin({
+const index$i = () => createPlugin({
   name: "Advanced Opener",
   description: "the fastest way to mass open blacket packs.",
   authors: [
@@ -2404,8 +2406,8 @@ const index$h = () => createPlugin({
     window.onresize = () => modal.style.top = modal.style.left = "";
   }
 });
-const __vite_glob_0_0 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$h }, Symbol.toStringTag, { value: "Module" }));
-const index$g = () => createPlugin({
+const __vite_glob_0_0 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$i }, Symbol.toStringTag, { value: "Module" }));
+const index$h = () => createPlugin({
   name: "Bazaar Sniper",
   description: "pew pew! sniped right off the bazaar!",
   authors: [{ name: "Death", avatar: "https://i.imgur.com/PrvNWub.png", url: "https://villainsrule.xyz" }],
@@ -2432,8 +2434,8 @@ Check the console for more information.`);
     }, 1e3);
   }
 });
-const __vite_glob_0_1 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$g }, Symbol.toStringTag, { value: "Module" }));
-const index$f = () => createPlugin({
+const __vite_glob_0_1 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$h }, Symbol.toStringTag, { value: "Module" }));
+const index$g = () => createPlugin({
   name: "Better Chat",
   description: "enhances your chatting experience!",
   authors: [{ name: "Death", avatar: "https://i.imgur.com/PrvNWub.png", url: "https://villainsrule.xyz" }],
@@ -2522,8 +2524,8 @@ const index$f = () => createPlugin({
     default: true
   }]
 });
-const __vite_glob_0_2 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$f }, Symbol.toStringTag, { value: "Module" }));
-const index$e = () => createPlugin({
+const __vite_glob_0_2 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$g }, Symbol.toStringTag, { value: "Module" }));
+const index$f = () => createPlugin({
   name: "Better Notifications",
   description: "a new and improved notification system.",
   authors: [{ name: "Death", avatar: "https://i.imgur.com/PrvNWub.png", url: "https://villainsrule.xyz" }],
@@ -2610,8 +2612,8 @@ const index$e = () => createPlugin({
     default: false
   }]
 });
-const __vite_glob_0_3 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$e }, Symbol.toStringTag, { value: "Module" }));
-const index$d = () => createPlugin({
+const __vite_glob_0_3 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$f }, Symbol.toStringTag, { value: "Module" }));
+const index$e = () => createPlugin({
   name: "Blook Utilities",
   description: "enhances the blook manager experience.",
   authors: [{ name: "Death", avatar: "https://i.imgur.com/PrvNWub.png", url: "https://villainsrule.xyz" }],
@@ -2854,7 +2856,7 @@ const index$d = () => createPlugin({
     };
   }
 });
-const __vite_glob_0_4 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$d }, Symbol.toStringTag, { value: "Module" }));
+const __vite_glob_0_4 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$e }, Symbol.toStringTag, { value: "Module" }));
 const badges = async (...args) => {
   if (args[0])
     axios$1.get("/worker2/user/" + args[0]).then((u) => {
@@ -3161,7 +3163,7 @@ const commands = {
   tokens,
   trade
 };
-const index$c = () => createPlugin({
+const index$d = () => createPlugin({
   name: "DeafBot",
   description: "the chatbot you know and love.",
   authors: [{ name: "Death", avatar: "https://i.imgur.com/PrvNWub.png", url: "https://villainsrule.xyz" }],
@@ -3201,8 +3203,8 @@ const index$c = () => createPlugin({
     };
   }
 });
-const __vite_glob_0_5 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$c }, Symbol.toStringTag, { value: "Module" }));
-const index$b = () => createPlugin({
+const __vite_glob_0_5 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$d }, Symbol.toStringTag, { value: "Module" }));
+const index$c = () => createPlugin({
   name: "Double Leaderboard",
   description: "see both leaderboards together.",
   authors: [{ name: "Death", avatar: "https://i.imgur.com/PrvNWub.png", url: "https://villainsrule.xyz" }],
@@ -3253,8 +3255,8 @@ const index$b = () => createPlugin({
         </style>`);
   }
 });
-const __vite_glob_0_6 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$b }, Symbol.toStringTag, { value: "Module" }));
-const index$a = () => createPlugin({
+const __vite_glob_0_6 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$c }, Symbol.toStringTag, { value: "Module" }));
+const index$b = () => createPlugin({
   name: "Extra Stats",
   description: "gives you extra stats for users.",
   authors: [{ name: "Death", avatar: "https://i.imgur.com/PrvNWub.png", url: "https://villainsrule.xyz" }],
@@ -3308,8 +3310,8 @@ const index$a = () => createPlugin({
         `);
   }
 });
-const __vite_glob_0_7 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$a }, Symbol.toStringTag, { value: "Module" }));
-const index$9 = () => createPlugin({
+const __vite_glob_0_7 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$b }, Symbol.toStringTag, { value: "Module" }));
+const index$a = () => createPlugin({
   name: "Highlight Rarity",
   description: "displays the rarity of Bazaar blooks.",
   authors: [{ name: "Death", avatar: "https://i.imgur.com/PrvNWub.png", url: "https://villainsrule.xyz" }],
@@ -3329,8 +3331,8 @@ const index$9 = () => createPlugin({
     }
   ]
 });
-const __vite_glob_0_8 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$9 }, Symbol.toStringTag, { value: "Module" }));
-const index$8 = () => createPlugin({
+const __vite_glob_0_8 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$a }, Symbol.toStringTag, { value: "Module" }));
+const index$9 = () => createPlugin({
   name: "Internals",
   description: "the internals of BetterBlacket.",
   authors: [{ name: "Internal" }],
@@ -3997,8 +3999,8 @@ const index$8 = () => createPlugin({
     });
   }
 });
-const __vite_glob_0_9 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$8 }, Symbol.toStringTag, { value: "Module" }));
-const index$7 = () => createPlugin({
+const __vite_glob_0_9 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$9 }, Symbol.toStringTag, { value: "Module" }));
+const index$8 = () => createPlugin({
   name: "Message Logger",
   description: "view deleted messages like a staff would.",
   authors: [{ name: "Death", avatar: "https://i.imgur.com/PrvNWub.png", url: "https://villainsrule.xyz" }],
@@ -4015,8 +4017,8 @@ const index$7 = () => createPlugin({
     }
   ]
 });
-const __vite_glob_0_10 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$7 }, Symbol.toStringTag, { value: "Module" }));
-const index$6 = () => createPlugin({
+const __vite_glob_0_10 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$8 }, Symbol.toStringTag, { value: "Module" }));
+const index$7 = () => createPlugin({
   name: "No Chat Color",
   description: "disables color in chat.",
   authors: [{ name: "Syfe", avatar: "https://i.imgur.com/OKpOipQ.gif", url: "https://github.com/ItsSyfe" }],
@@ -4054,8 +4056,8 @@ const index$6 = () => createPlugin({
     { name: "No Clan Colors", default: true }
   ]
 });
-const __vite_glob_0_11 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$6 }, Symbol.toStringTag, { value: "Module" }));
-const index$5 = () => createPlugin({
+const __vite_glob_0_11 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$7 }, Symbol.toStringTag, { value: "Module" }));
+const index$6 = () => createPlugin({
   name: "No Chat Ping",
   description: "prevents you from being pinged in chat.",
   authors: [{ name: "Death", avatar: "https://i.imgur.com/PrvNWub.png", url: "https://villainsrule.xyz" }],
@@ -4085,8 +4087,8 @@ const index$5 = () => createPlugin({
     }
   ]
 });
-const __vite_glob_0_12 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$5 }, Symbol.toStringTag, { value: "Module" }));
-const index$4 = () => createPlugin({
+const __vite_glob_0_12 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$6 }, Symbol.toStringTag, { value: "Module" }));
+const index$5 = () => createPlugin({
   name: "No Devtools Warning",
   description: "disables the warning in the console.",
   authors: [{ name: "Death", avatar: "https://i.imgur.com/PrvNWub.png", url: "https://villainsrule.xyz" }],
@@ -4102,8 +4104,8 @@ const index$4 = () => createPlugin({
     }
   ]
 });
-const __vite_glob_0_13 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$4 }, Symbol.toStringTag, { value: "Module" }));
-const index$3 = () => createPlugin({
+const __vite_glob_0_13 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$5 }, Symbol.toStringTag, { value: "Module" }));
+const index$4 = () => createPlugin({
   name: "Quick CSS",
   description: "edit CSS for the game and have it applied instantly.",
   authors: [{ name: "Death", avatar: "https://i.imgur.com/PrvNWub.png", url: "https://villainsrule.xyz" }],
@@ -4228,8 +4230,8 @@ const index$3 = () => createPlugin({
     };
   }
 });
-const __vite_glob_0_14 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$3 }, Symbol.toStringTag, { value: "Module" }));
-const index$2 = () => createPlugin({
+const __vite_glob_0_14 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$4 }, Symbol.toStringTag, { value: "Module" }));
+const index$3 = () => createPlugin({
   name: "Real Total blooks",
   description: "displays the true number of total blooks on the stats page.",
   authors: [{ name: "Death", avatar: "https://i.imgur.com/PrvNWub.png", url: "https://villainsrule.xyz" }],
@@ -4245,8 +4247,8 @@ const index$2 = () => createPlugin({
     }
   ]
 });
-const __vite_glob_0_15 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$2 }, Symbol.toStringTag, { value: "Module" }));
-const index$1 = () => createPlugin({
+const __vite_glob_0_15 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$3 }, Symbol.toStringTag, { value: "Module" }));
+const index$2 = () => createPlugin({
   name: "Reply Fix",
   description: "fixes blacket's broken replies.",
   authors: [{ name: "Syfe", avatar: "https://i.imgur.com/OKpOipQ.gif", url: "https://github.com/ItsSyfe" }],
@@ -4268,8 +4270,8 @@ const index$1 = () => createPlugin({
     }
   ]
 });
-const __vite_glob_0_16 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$1 }, Symbol.toStringTag, { value: "Module" }));
-const index = () => createPlugin({
+const __vite_glob_0_16 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$2 }, Symbol.toStringTag, { value: "Module" }));
+const index$1 = () => createPlugin({
   name: "Staff Tags",
   description: "gives staff who speak in chat a special tag.",
   authors: [{ name: "Death", avatar: "https://i.imgur.com/PrvNWub.png", url: "https://villainsrule.xyz" }],
@@ -4305,7 +4307,43 @@ const index = () => createPlugin({
     }
   ]
 });
-const __vite_glob_0_17 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index }, Symbol.toStringTag, { value: "Module" }));
+const __vite_glob_0_17 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$1 }, Symbol.toStringTag, { value: "Module" }));
+const index = () => createPlugin({
+  name: "Faster",
+  description: "Attempt to make blacket run faster.",
+  authors: [{ name: "zastix", avatar: "https://zastix.club/resources/pfps/pfp_crop.png", url: "https://zastix.club" }],
+  patches: [
+    {
+      file: "/lib/js/stats.js",
+      replacement: [
+        {
+          match: /Object\.keys\(blacket.friends.friends\)/,
+          replace: `$self.getFriends()`,
+          setting: "No Friends"
+        },
+        {
+          match: /user\.clan == null/,
+          replace: `true`,
+          setting: "No Clan On Stats"
+        }
+      ]
+    }
+  ],
+  settings: [
+    {
+      name: "No Friends",
+      default: true
+    },
+    {
+      name: "No Clan On Stats",
+      default: true
+    }
+  ],
+  getFriends() {
+    return [];
+  }
+});
+const __vite_glob_0_18 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index }, Symbol.toStringTag, { value: "Module" }));
 const patcher = () => {
   let blacklistedKeywords = ["cdn-cgi", "jquery", "jscolor"];
   let scripts = [...document.querySelectorAll("script")].filter((script) => !blacklistedKeywords.some((k) => script.src.includes(k))).filter((script) => script.src.includes(location.host)).map((script) => script.src);
@@ -4328,6 +4366,7 @@ const patcher = () => {
                     continue;
                   } else if (replacement.setting)
                     console.log("Setting", replacement.setting, "is active, applying...");
+                  replacement.replace = replacement.replace.replace("$self", `bb.plugins.list.find(a => a.name === '${patch.plugin}')`);
                   const matchRegex = new RegExp(replacement.match, "gm");
                   if (!matchRegex.test(data)) {
                     console.log(`Patch did nothing! Plugin: ${patch.plugin}; Regex: \`${replacement.match}\`.`);
@@ -4385,7 +4424,7 @@ ${url}`);
 const loadPlugins = async () => {
   let pluginData = storage.get("bb_pluginData", true);
   let contentLoaded = false;
-  await Promise.all(Object.values(/* @__PURE__ */ Object.assign({ "../plugins/advancedopen/index.js": __vite_glob_0_0, "../plugins/bazaarsniper/index.js": __vite_glob_0_1, "../plugins/betterchat/index.js": __vite_glob_0_2, "../plugins/betternotifications/index.js": __vite_glob_0_3, "../plugins/blookutils/index.js": __vite_glob_0_4, "../plugins/deafbot/index.js": __vite_glob_0_5, "../plugins/doubleleaderboard/index.js": __vite_glob_0_6, "../plugins/extrastats/index.js": __vite_glob_0_7, "../plugins/highlightrarity/index.js": __vite_glob_0_8, "../plugins/internals/index.js": __vite_glob_0_9, "../plugins/messagelogger/index.js": __vite_glob_0_10, "../plugins/nochatcolor/index.js": __vite_glob_0_11, "../plugins/nochatping/index.js": __vite_glob_0_12, "../plugins/nodevtoolswarn/index.js": __vite_glob_0_13, "../plugins/quickcss/index.js": __vite_glob_0_14, "../plugins/realtotalblooks/index.js": __vite_glob_0_15, "../plugins/replyfix/index.js": __vite_glob_0_16, "../plugins/stafftags/index.js": __vite_glob_0_17 })).map(async (pluginFile) => {
+  await Promise.all(Object.values(/* @__PURE__ */ Object.assign({ "../plugins/advancedopen/index.js": __vite_glob_0_0, "../plugins/bazaarsniper/index.js": __vite_glob_0_1, "../plugins/betterchat/index.js": __vite_glob_0_2, "../plugins/betternotifications/index.js": __vite_glob_0_3, "../plugins/blookutils/index.js": __vite_glob_0_4, "../plugins/deafbot/index.js": __vite_glob_0_5, "../plugins/doubleleaderboard/index.js": __vite_glob_0_6, "../plugins/extrastats/index.js": __vite_glob_0_7, "../plugins/highlightrarity/index.js": __vite_glob_0_8, "../plugins/internals/index.js": __vite_glob_0_9, "../plugins/messagelogger/index.js": __vite_glob_0_10, "../plugins/nochatcolor/index.js": __vite_glob_0_11, "../plugins/nochatping/index.js": __vite_glob_0_12, "../plugins/nodevtoolswarn/index.js": __vite_glob_0_13, "../plugins/quickcss/index.js": __vite_glob_0_14, "../plugins/realtotalblooks/index.js": __vite_glob_0_15, "../plugins/replyfix/index.js": __vite_glob_0_16, "../plugins/stafftags/index.js": __vite_glob_0_17, "../userplugins/faster/index.js": __vite_glob_0_18 })).map(async (pluginFile) => {
     let plugin = pluginFile.default();
     bb.plugins.list.push(plugin);
     if (!!plugin.styles)

--- a/dist/bb.user.js
+++ b/dist/bb.user.js
@@ -2176,7 +2176,8 @@ const createPlugin = ({
   onLoad,
   onStart,
   required,
-  disabled
+  disabled,
+  ...custom
 }) => {
   if (!name || !authors?.length || !onLoad && !onStart && !patches && !styles)
     return console.error(`ERROR: Plugin does not have a title, authors, or executable functions.`);
@@ -2192,11 +2193,12 @@ const createPlugin = ({
     onStart: onStart || (() => {
     }),
     required: required || false,
-    disabled: disabled || false
+    disabled: disabled || false,
+    ...custom
   };
   return plugin;
 };
-const index$h = () => createPlugin({
+const index$i = () => createPlugin({
   name: "Advanced Opener",
   description: "the fastest way to mass open blacket packs.",
   authors: [
@@ -2426,8 +2428,8 @@ const index$h = () => createPlugin({
     window.onresize = () => modal.style.top = modal.style.left = "";
   }
 });
-const __vite_glob_0_0 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$h }, Symbol.toStringTag, { value: "Module" }));
-const index$g = () => createPlugin({
+const __vite_glob_0_0 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$i }, Symbol.toStringTag, { value: "Module" }));
+const index$h = () => createPlugin({
   name: "Bazaar Sniper",
   description: "pew pew! sniped right off the bazaar!",
   authors: [{ name: "Death", avatar: "https://i.imgur.com/PrvNWub.png", url: "https://villainsrule.xyz" }],
@@ -2454,8 +2456,8 @@ Check the console for more information.`);
     }, 1e3);
   }
 });
-const __vite_glob_0_1 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$g }, Symbol.toStringTag, { value: "Module" }));
-const index$f = () => createPlugin({
+const __vite_glob_0_1 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$h }, Symbol.toStringTag, { value: "Module" }));
+const index$g = () => createPlugin({
   name: "Better Chat",
   description: "enhances your chatting experience!",
   authors: [{ name: "Death", avatar: "https://i.imgur.com/PrvNWub.png", url: "https://villainsrule.xyz" }],
@@ -2544,8 +2546,8 @@ const index$f = () => createPlugin({
     default: true
   }]
 });
-const __vite_glob_0_2 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$f }, Symbol.toStringTag, { value: "Module" }));
-const index$e = () => createPlugin({
+const __vite_glob_0_2 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$g }, Symbol.toStringTag, { value: "Module" }));
+const index$f = () => createPlugin({
   name: "Better Notifications",
   description: "a new and improved notification system.",
   authors: [{ name: "Death", avatar: "https://i.imgur.com/PrvNWub.png", url: "https://villainsrule.xyz" }],
@@ -2632,8 +2634,8 @@ const index$e = () => createPlugin({
     default: false
   }]
 });
-const __vite_glob_0_3 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$e }, Symbol.toStringTag, { value: "Module" }));
-const index$d = () => createPlugin({
+const __vite_glob_0_3 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$f }, Symbol.toStringTag, { value: "Module" }));
+const index$e = () => createPlugin({
   name: "Blook Utilities",
   description: "enhances the blook manager experience.",
   authors: [{ name: "Death", avatar: "https://i.imgur.com/PrvNWub.png", url: "https://villainsrule.xyz" }],
@@ -2876,7 +2878,7 @@ const index$d = () => createPlugin({
     };
   }
 });
-const __vite_glob_0_4 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$d }, Symbol.toStringTag, { value: "Module" }));
+const __vite_glob_0_4 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$e }, Symbol.toStringTag, { value: "Module" }));
 const badges = async (...args) => {
   if (args[0])
     axios$1.get("/worker2/user/" + args[0]).then((u) => {
@@ -3183,7 +3185,7 @@ const commands = {
   tokens,
   trade
 };
-const index$c = () => createPlugin({
+const index$d = () => createPlugin({
   name: "DeafBot",
   description: "the chatbot you know and love.",
   authors: [{ name: "Death", avatar: "https://i.imgur.com/PrvNWub.png", url: "https://villainsrule.xyz" }],
@@ -3223,8 +3225,8 @@ const index$c = () => createPlugin({
     };
   }
 });
-const __vite_glob_0_5 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$c }, Symbol.toStringTag, { value: "Module" }));
-const index$b = () => createPlugin({
+const __vite_glob_0_5 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$d }, Symbol.toStringTag, { value: "Module" }));
+const index$c = () => createPlugin({
   name: "Double Leaderboard",
   description: "see both leaderboards together.",
   authors: [{ name: "Death", avatar: "https://i.imgur.com/PrvNWub.png", url: "https://villainsrule.xyz" }],
@@ -3275,8 +3277,8 @@ const index$b = () => createPlugin({
         </style>`);
   }
 });
-const __vite_glob_0_6 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$b }, Symbol.toStringTag, { value: "Module" }));
-const index$a = () => createPlugin({
+const __vite_glob_0_6 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$c }, Symbol.toStringTag, { value: "Module" }));
+const index$b = () => createPlugin({
   name: "Extra Stats",
   description: "gives you extra stats for users.",
   authors: [{ name: "Death", avatar: "https://i.imgur.com/PrvNWub.png", url: "https://villainsrule.xyz" }],
@@ -3330,8 +3332,8 @@ const index$a = () => createPlugin({
         `);
   }
 });
-const __vite_glob_0_7 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$a }, Symbol.toStringTag, { value: "Module" }));
-const index$9 = () => createPlugin({
+const __vite_glob_0_7 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$b }, Symbol.toStringTag, { value: "Module" }));
+const index$a = () => createPlugin({
   name: "Highlight Rarity",
   description: "displays the rarity of Bazaar blooks.",
   authors: [{ name: "Death", avatar: "https://i.imgur.com/PrvNWub.png", url: "https://villainsrule.xyz" }],
@@ -3351,8 +3353,8 @@ const index$9 = () => createPlugin({
     }
   ]
 });
-const __vite_glob_0_8 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$9 }, Symbol.toStringTag, { value: "Module" }));
-const index$8 = () => createPlugin({
+const __vite_glob_0_8 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$a }, Symbol.toStringTag, { value: "Module" }));
+const index$9 = () => createPlugin({
   name: "Internals",
   description: "the internals of BetterBlacket.",
   authors: [{ name: "Internal" }],
@@ -4019,8 +4021,8 @@ const index$8 = () => createPlugin({
     });
   }
 });
-const __vite_glob_0_9 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$8 }, Symbol.toStringTag, { value: "Module" }));
-const index$7 = () => createPlugin({
+const __vite_glob_0_9 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$9 }, Symbol.toStringTag, { value: "Module" }));
+const index$8 = () => createPlugin({
   name: "Message Logger",
   description: "view deleted messages like a staff would.",
   authors: [{ name: "Death", avatar: "https://i.imgur.com/PrvNWub.png", url: "https://villainsrule.xyz" }],
@@ -4037,8 +4039,8 @@ const index$7 = () => createPlugin({
     }
   ]
 });
-const __vite_glob_0_10 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$7 }, Symbol.toStringTag, { value: "Module" }));
-const index$6 = () => createPlugin({
+const __vite_glob_0_10 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$8 }, Symbol.toStringTag, { value: "Module" }));
+const index$7 = () => createPlugin({
   name: "No Chat Color",
   description: "disables color in chat.",
   authors: [{ name: "Syfe", avatar: "https://i.imgur.com/OKpOipQ.gif", url: "https://github.com/ItsSyfe" }],
@@ -4076,8 +4078,8 @@ const index$6 = () => createPlugin({
     { name: "No Clan Colors", default: true }
   ]
 });
-const __vite_glob_0_11 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$6 }, Symbol.toStringTag, { value: "Module" }));
-const index$5 = () => createPlugin({
+const __vite_glob_0_11 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$7 }, Symbol.toStringTag, { value: "Module" }));
+const index$6 = () => createPlugin({
   name: "No Chat Ping",
   description: "prevents you from being pinged in chat.",
   authors: [{ name: "Death", avatar: "https://i.imgur.com/PrvNWub.png", url: "https://villainsrule.xyz" }],
@@ -4107,8 +4109,8 @@ const index$5 = () => createPlugin({
     }
   ]
 });
-const __vite_glob_0_12 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$5 }, Symbol.toStringTag, { value: "Module" }));
-const index$4 = () => createPlugin({
+const __vite_glob_0_12 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$6 }, Symbol.toStringTag, { value: "Module" }));
+const index$5 = () => createPlugin({
   name: "No Devtools Warning",
   description: "disables the warning in the console.",
   authors: [{ name: "Death", avatar: "https://i.imgur.com/PrvNWub.png", url: "https://villainsrule.xyz" }],
@@ -4124,8 +4126,8 @@ const index$4 = () => createPlugin({
     }
   ]
 });
-const __vite_glob_0_13 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$4 }, Symbol.toStringTag, { value: "Module" }));
-const index$3 = () => createPlugin({
+const __vite_glob_0_13 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$5 }, Symbol.toStringTag, { value: "Module" }));
+const index$4 = () => createPlugin({
   name: "Quick CSS",
   description: "edit CSS for the game and have it applied instantly.",
   authors: [{ name: "Death", avatar: "https://i.imgur.com/PrvNWub.png", url: "https://villainsrule.xyz" }],
@@ -4250,8 +4252,8 @@ const index$3 = () => createPlugin({
     };
   }
 });
-const __vite_glob_0_14 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$3 }, Symbol.toStringTag, { value: "Module" }));
-const index$2 = () => createPlugin({
+const __vite_glob_0_14 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$4 }, Symbol.toStringTag, { value: "Module" }));
+const index$3 = () => createPlugin({
   name: "Real Total blooks",
   description: "displays the true number of total blooks on the stats page.",
   authors: [{ name: "Death", avatar: "https://i.imgur.com/PrvNWub.png", url: "https://villainsrule.xyz" }],
@@ -4267,8 +4269,8 @@ const index$2 = () => createPlugin({
     }
   ]
 });
-const __vite_glob_0_15 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$2 }, Symbol.toStringTag, { value: "Module" }));
-const index$1 = () => createPlugin({
+const __vite_glob_0_15 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$3 }, Symbol.toStringTag, { value: "Module" }));
+const index$2 = () => createPlugin({
   name: "Reply Fix",
   description: "fixes blacket's broken replies.",
   authors: [{ name: "Syfe", avatar: "https://i.imgur.com/OKpOipQ.gif", url: "https://github.com/ItsSyfe" }],
@@ -4290,8 +4292,8 @@ const index$1 = () => createPlugin({
     }
   ]
 });
-const __vite_glob_0_16 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$1 }, Symbol.toStringTag, { value: "Module" }));
-const index = () => createPlugin({
+const __vite_glob_0_16 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$2 }, Symbol.toStringTag, { value: "Module" }));
+const index$1 = () => createPlugin({
   name: "Staff Tags",
   description: "gives staff who speak in chat a special tag.",
   authors: [{ name: "Death", avatar: "https://i.imgur.com/PrvNWub.png", url: "https://villainsrule.xyz" }],
@@ -4327,7 +4329,43 @@ const index = () => createPlugin({
     }
   ]
 });
-const __vite_glob_0_17 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index }, Symbol.toStringTag, { value: "Module" }));
+const __vite_glob_0_17 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index$1 }, Symbol.toStringTag, { value: "Module" }));
+const index = () => createPlugin({
+  name: "Faster",
+  description: "Attempt to make blacket run faster.",
+  authors: [{ name: "zastix", avatar: "https://zastix.club/resources/pfps/pfp_crop.png", url: "https://zastix.club" }],
+  patches: [
+    {
+      file: "/lib/js/stats.js",
+      replacement: [
+        {
+          match: /Object\.keys\(blacket.friends.friends\)/,
+          replace: `$self.getFriends()`,
+          setting: "No Friends"
+        },
+        {
+          match: /user\.clan == null/,
+          replace: `true`,
+          setting: "No Clan On Stats"
+        }
+      ]
+    }
+  ],
+  settings: [
+    {
+      name: "No Friends",
+      default: true
+    },
+    {
+      name: "No Clan On Stats",
+      default: true
+    }
+  ],
+  getFriends() {
+    return [];
+  }
+});
+const __vite_glob_0_18 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({ __proto__: null, default: index }, Symbol.toStringTag, { value: "Module" }));
 const patcher = () => {
   let blacklistedKeywords = ["cdn-cgi", "jquery", "jscolor"];
   let scripts = [...document.querySelectorAll("script")].filter((script) => !blacklistedKeywords.some((k) => script.src.includes(k))).filter((script) => script.src.includes(location.host)).map((script) => script.src);
@@ -4350,6 +4388,7 @@ const patcher = () => {
                     continue;
                   } else if (replacement.setting)
                     console.log("Setting", replacement.setting, "is active, applying...");
+                  replacement.replace = replacement.replace.replace("$self", `bb.plugins.list.find(a => a.name === '${patch.plugin}')`);
                   const matchRegex = new RegExp(replacement.match, "gm");
                   if (!matchRegex.test(data)) {
                     console.log(`Patch did nothing! Plugin: ${patch.plugin}; Regex: \`${replacement.match}\`.`);
@@ -4407,7 +4446,7 @@ ${url}`);
 const loadPlugins = async () => {
   let pluginData = storage.get("bb_pluginData", true);
   let contentLoaded = false;
-  await Promise.all(Object.values(/* @__PURE__ */ Object.assign({ "../plugins/advancedopen/index.js": __vite_glob_0_0, "../plugins/bazaarsniper/index.js": __vite_glob_0_1, "../plugins/betterchat/index.js": __vite_glob_0_2, "../plugins/betternotifications/index.js": __vite_glob_0_3, "../plugins/blookutils/index.js": __vite_glob_0_4, "../plugins/deafbot/index.js": __vite_glob_0_5, "../plugins/doubleleaderboard/index.js": __vite_glob_0_6, "../plugins/extrastats/index.js": __vite_glob_0_7, "../plugins/highlightrarity/index.js": __vite_glob_0_8, "../plugins/internals/index.js": __vite_glob_0_9, "../plugins/messagelogger/index.js": __vite_glob_0_10, "../plugins/nochatcolor/index.js": __vite_glob_0_11, "../plugins/nochatping/index.js": __vite_glob_0_12, "../plugins/nodevtoolswarn/index.js": __vite_glob_0_13, "../plugins/quickcss/index.js": __vite_glob_0_14, "../plugins/realtotalblooks/index.js": __vite_glob_0_15, "../plugins/replyfix/index.js": __vite_glob_0_16, "../plugins/stafftags/index.js": __vite_glob_0_17 })).map(async (pluginFile) => {
+  await Promise.all(Object.values(/* @__PURE__ */ Object.assign({ "../plugins/advancedopen/index.js": __vite_glob_0_0, "../plugins/bazaarsniper/index.js": __vite_glob_0_1, "../plugins/betterchat/index.js": __vite_glob_0_2, "../plugins/betternotifications/index.js": __vite_glob_0_3, "../plugins/blookutils/index.js": __vite_glob_0_4, "../plugins/deafbot/index.js": __vite_glob_0_5, "../plugins/doubleleaderboard/index.js": __vite_glob_0_6, "../plugins/extrastats/index.js": __vite_glob_0_7, "../plugins/highlightrarity/index.js": __vite_glob_0_8, "../plugins/internals/index.js": __vite_glob_0_9, "../plugins/messagelogger/index.js": __vite_glob_0_10, "../plugins/nochatcolor/index.js": __vite_glob_0_11, "../plugins/nochatping/index.js": __vite_glob_0_12, "../plugins/nodevtoolswarn/index.js": __vite_glob_0_13, "../plugins/quickcss/index.js": __vite_glob_0_14, "../plugins/realtotalblooks/index.js": __vite_glob_0_15, "../plugins/replyfix/index.js": __vite_glob_0_16, "../plugins/stafftags/index.js": __vite_glob_0_17, "../userplugins/faster/index.js": __vite_glob_0_18 })).map(async (pluginFile) => {
     let plugin = pluginFile.default();
     bb.plugins.list.push(plugin);
     if (!!plugin.styles)

--- a/src/internals/patcher.js
+++ b/src/internals/patcher.js
@@ -27,13 +27,14 @@ export default () => {
                                     console.log('Setting', replacement.setting, 'is not active, ignoring...');
                                     continue;
                                 } else if (replacement.setting) console.log('Setting', replacement.setting, 'is active, applying...');
-
                                 const matchRegex = new RegExp(replacement.match, 'gm');
                                 if (!matchRegex.test(data)) {
                                     console.log(`Patch did nothing! Plugin: ${patch.plugin}; Regex: \`${replacement.match}\`.`);
                                     continue;
                                 };
 
+
+                                replacement.replace = replacement.replace.replace('$self', `bb.plugins.list.find(a => a.name === '${patch.plugin}')`);
                                 data = data.replaceAll(matchRegex, replacement.replace);
                             };
 

--- a/src/internals/patcher.js
+++ b/src/internals/patcher.js
@@ -33,7 +33,6 @@ export default () => {
                                     continue;
                                 };
 
-
                                 replacement.replace = replacement.replace.replace('$self', `bb.plugins.list.find(a => a.name === '${patch.plugin}')`);
                                 data = data.replaceAll(matchRegex, replacement.replace);
                             };

--- a/src/utils/createPlugin.js
+++ b/src/utils/createPlugin.js
@@ -8,7 +8,8 @@ export default ({
     onLoad,
     onStart,
     required,
-    disabled
+    disabled,
+    ...custom
 }) => {
     if (!name || !authors?.length || (!onLoad && !onStart && !patches && !styles)) return console.error(`ERROR: Plugin does not have a title, authors, or executable functions.`);
     
@@ -22,7 +23,8 @@ export default ({
         onLoad: onLoad || (() => { }),
         onStart: onStart || (() => { }),
         required: required || false,
-        disabled: disabled || false
+        disabled: disabled || false,
+        ...custom
     };
 
     return plugin;

--- a/userscript/build.js
+++ b/userscript/build.js
@@ -4,6 +4,7 @@ import * as childproc from 'child_process';
 import * as url from 'url';
 
 const copyToClip = (data) => {
+    return;
     let proc = childproc.spawn({
         'darwin': 'pbcopy',
         'win32': 'clip',

--- a/userscript/build.js
+++ b/userscript/build.js
@@ -4,7 +4,6 @@ import * as childproc from 'child_process';
 import * as url from 'url';
 
 const copyToClip = (data) => {
-    return;
     let proc = childproc.spawn({
         'darwin': 'pbcopy',
         'win32': 'clip',


### PR DESCRIPTION
Allow plugins to reference themselves in patches and add custom methods.

Example:
```js
createPlugin({
    name: 'Example',
    description: 'Example for $self',
    authors: [{ name: 'zastix', avatar: 'https://zastix.club/resources/pfps/pfp_crop.png', url: 'https://zastix.club' }],
    patches: [
        {
            file: '/lib/js/stats.js',
            replacement: [
                {
                    match: /Object\.keys\(blacket.friends.friends\)/,
                    replace: `$self.getFriends()`,
                    setting: 'No Friends'
                },
            ]
        }
    ],
    settings: [
        {
            name: 'No Friends',
            default: true
        }
    ],
    getFriends() {
        return [];
    }
});
```